### PR TITLE
Fix a couple of compatibility issues with previous client gems

### DIFF
--- a/lib/plaza/adapters/base_adapter.rb
+++ b/lib/plaza/adapters/base_adapter.rb
@@ -1,27 +1,24 @@
 module Plaza
   module BaseAdapter
-    def handle_response(response)
-      begin
-        if response.success?
-          return response_to_hash(response)
-        else
-          handle_error(response)
-        end
-      rescue JSON::ParserError=> jsonError
-        error = Plaza::Error.new(jsonError, jsonError.message)
-        raise(error,error.to_s )
+    def handle_response
+      response = yield
+      if response.success?
+        return response_to_hash(response)
+      else
+        handle_error(response)
       end
     end
 
     def handle_error(response)
-      response_hash = response_to_hash(response)
+      response_hash =  response_to_hash(response)
       error_hash = response_hash.has_key?(:error) ? response_hash[:error] : response_hash["error"]
       unless error_hash
         error_hash = response_hash.has_key?(:errors) ? response_hash[:errors] : response_hash["errors"]
       end
+
       #test for both singular error and plural errors
-      logger.warn("Response returned an error code #{response.status} - #{response_hash}")
-      case response.status.to_i
+      logger.warn("Response returned an error code #{response.code} - #{response_hash}")
+      case response.code
         when 422
           error = Plaza::ResourceInvalid.new(response, "#{error_hash}", error_hash)
       else
@@ -31,10 +28,15 @@ module Plaza
     end
 
     def response_to_hash(response)
-      if response.body.kind_of? Hash
-        response.body
-      else
-        JSON.parse(response)
+      begin
+        if response.body.kind_of? Hash
+          response.body
+        else
+          JSON.parse(response)
+        end
+      rescue JSON::ParserError=> jsonError
+        error = Plaza::Error.new(jsonError, jsonError.message)
+        raise(error, error.to_s )
       end
     end
   end

--- a/lib/plaza/adapters/restful_adapter.rb
+++ b/lib/plaza/adapters/restful_adapter.rb
@@ -1,46 +1,48 @@
 class Plaza::RestfulAdapter
   include Plaza::BaseAdapter
-  attr_reader :request, :logger
+  attr_reader :request, :logger, :restful_path
 
   def initialize(resource)
     @singular_name = resource.singular_name
     @plural_name   = resource.plural_name
     @request = Plaza::Request.new(resource.plaza_config)
     @logger  = Plaza.configuration(resource.plaza_config).logger
+    @restful_path = Plaza.configuration(resource.plaza_config).restful_path
   end
 
   def index(query_params = nil)
-    handle_response(request.get(base_url(query_params)))
+    handle_response{request.get(base_url(query_params))}
   end
 
   def show(id)
-    hash = handle_response(request.get(resource_url(id)))
+    hash = handle_response{request.get(resource_url(id))}
     hash.fetch(@singular_name){hash}
   end
 
   def update(id, data)
-    hash = handle_response(request.put(resource_url(id), data))
+    hash = handle_response{request.put(resource_url(id), data)}
     hash.fetch(@singular_name){hash}
   end
 
   def create(data)
-    hash = handle_response(request.post(base_url, data))
+    hash = handle_response{request.post(base_url, data)}
     hash.fetch(@singular_name){hash}
   end
 
   def delete(id)
-    hash = handle_response(request.delete(resource_url(id)))
+    hash = handle_response{request.delete(resource_url(id))}
     hash.fetch(@singular_name){hash}
   end
 
   def has_many(id, relation)
-    hash = handle_response(request.get(has_many_url(id,relation)))
+    hash = handle_response{request.get(has_many_url(id,relation))}
     hash.fetch(@singular_name){hash}
   end
 
   private
   def base_url(query_params = nil)
-    url = "#{@plural_name}.json"
+    url = restful_path ? "#{restful_path}/" : ""
+    url << "#{@plural_name}.json"
     url << "?#{URI.encode_www_form(query_params)}" if query_params
     url
   end

--- a/lib/plaza/configuration.rb
+++ b/lib/plaza/configuration.rb
@@ -28,6 +28,10 @@ module Plaza
     end
     alias_method :cache_store=, :cache_store
 
+    def restful_path(path = nil)
+      path ? @restful_path = path : @restful_path
+    end
+
     def logger(logger = nil)
       @logger ||= Logger.new(STDOUT)
       logger ? @logger = logger : @logger

--- a/lib/plaza/connection.rb
+++ b/lib/plaza/connection.rb
@@ -5,16 +5,20 @@ module Plaza
       config = Plaza.configuration(config_sym)
       Faraday.new(config.base_url) do |conn|
         conn.request :json
+        conn.request :request_id
         conn.response :json, :content_type => /\bjson$/
 
         config.middleware.each do |middleware|
           conn.use middleware
         end
-        conn.use :http_cache, store: config.cache_store, logger: config.logger
+        
+        conn.use :http_cache, store: config.cache_store, logger: config.logger if config.cache_store
 
         conn.headers[:accept] = 'application/json'
 
         conn.adapter Faraday.default_adapter
+        conn.response :selective_errors, except: [422]
+        conn.use :extended_logging, logger: config.logger 
       end
     end
 

--- a/lib/plaza/middleware/exceptions.rb
+++ b/lib/plaza/middleware/exceptions.rb
@@ -8,6 +8,9 @@ module Plaza::Middleware
       rescue Faraday::Error::ConnectionFailed => e
         error = Plaza::ConnectionError.new(nil, 'Service is not available.')
         raise(error, error.to_s)
+      rescue Faraday::Error::ResourceNotFound => e
+        error = Plaza::Error.new(e.response, 'Resource Not Found')
+        raise(error, error.to_s)
       end
     end
   end

--- a/lib/plaza/models/base_model.rb
+++ b/lib/plaza/models/base_model.rb
@@ -33,8 +33,8 @@ module Plaza
       {singular_name => attributes}
     end
 
-    def to_json
-      self.serialize.to_json
+    def to_json(*args)
+      self.serialize.to_json(*args)
     end
   end
 end

--- a/lib/plaza/models/error.rb
+++ b/lib/plaza/models/error.rb
@@ -1,5 +1,5 @@
 module Plaza
-  class Error < ::StandardError
+  class Error < ::RuntimeError
     attr_reader :response
 
     def initialize(response, message = nil)
@@ -9,7 +9,7 @@ module Plaza
     end
 
     def status
-      response.respond_to?(:status) ? response.status : nil
+      response.respond_to?(:code) ? response.code : nil
     end
 
     def to_s

--- a/lib/plaza/request.rb
+++ b/lib/plaza/request.rb
@@ -1,6 +1,7 @@
 require 'faraday'
 require 'faraday/http_cache'
 require 'faraday_middleware'
+require "faraday/conductivity"
 require_relative 'middleware/user_id'
 require_relative 'middleware/exceptions'
 

--- a/lib/plaza/response.rb
+++ b/lib/plaza/response.rb
@@ -3,28 +3,40 @@ require 'delegate'
 module Plaza
   class Response < SimpleDelegator
     def success?
-      status.to_s[0].to_i == 2
+      code.to_s[0].to_i == 2
     end
 
     def redirected?
-      status.to_s[0].to_i == 3
+      code.to_s[0].to_i == 3
     end
 
     def failed?
-      [4, 5].include?(status.to_s[0].to_i)
+      [4, 5].include?(code.to_s[0].to_i)
     end
 
     def to_str
       body.to_s
     end
 
+    def headers
+      get_from_method_or_accessor(:headers)
+    end
+
+    def body
+      get_from_method_or_accessor(:body)
+    end
+
     def code
-      status
+      get_from_method_or_accessor(:status).to_i
     end
 
     private
     def object
       __getobj__
+    end
+
+    def get_from_method_or_accessor(attribute_symbol)
+      object.respond_to?(attribute_symbol) ? object.send(attribute_symbol) : object[attribute_symbol]
     end
   end
 end

--- a/plaza.gemspec
+++ b/plaza.gemspec
@@ -26,5 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'faraday', '~> 0.9.0'
   spec.add_runtime_dependency 'faraday_middleware', '~>0.9.1'
   spec.add_runtime_dependency 'faraday-http-cache', '~>0.4.2'
+  spec.add_runtime_dependency 'faraday-conductivity', '~>0.3.1'
   spec.add_runtime_dependency "virtus", '~> 1.0'
 end


### PR DESCRIPTION
Change signature of to_json to match JSON gem, which fixes a bug in create

add back in request id handling via the conductivity middleware gem
Make it so that we can catch exceptions in handle_response if the underlying request object throws an exception by wrapping instead of passing the request object
Change has_many functionality to first check in the current classes namespace for the associating class, then move all the way up the stack
